### PR TITLE
Генерация корреспондентского счета

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 * [ОКПО](http://ru.wikipedia.org/wiki/Общероссийский_классификатор_предприятий_и_организаций) (Faker::Russian.okpo)
 * [КПП](http://ru.wikipedia.org/wiki/Код_причины_постановки_на_учёт) (Faker::Russian.kpp)
 * (TODO) [ОГРН](http://ru.wikipedia.org/wiki/Основной_государственный_регистрационный_номер) (Faker::Russian.ogrn)
-* (TODO) [Корреспондентский счёт] (http://ru.wikipedia.org/wiki/Корреспондентский_счёт) (Faker::Russian.ks)
+* [Корреспондентский счёт] (http://ru.wikipedia.org/wiki/Корреспондентский_счёт) (Faker::Russian.correspondent_account)
 * (TODO) [Рассчётный счёт] (http://ru.wikipedia.org/wiki/Расчётный_счёт) (Faker::Russian.rs)
 * [OKATO](http://ru.wikipedia.org/wiki/Общероссийский_классификатор_объектов_административно-территориального_деления) (Faker::Russian.okato)
 * (TODO) [СНИЛС](http://ru.wikipedia.org/wiki/Страховой_номер_индивидуального_лицевого_счёта) (Faker::Russian.snils)
@@ -106,6 +106,27 @@
 ``` ruby
   Faker::Russian.kpp(sequence_number: 1) # => '381201001'
   Faker::Russian.kpp(sequence_number: 1) # => '381201001'
+```
+
+### Корреспондентский счёт
+
+Генерируется корреспондентский счет
+
+```ruby
+  Faker::Russian.correspondent_account
+```
+
+Также можно использовать последовательности (не более 1 000 000 000):
+
+``` ruby
+  Faker::Russian.correspondent_account(sequence_number: 1) # => '30100000000717354021'
+  Faker::Russian.correspondent_account(sequence_number: 1) # => '30100000000717354021'
+```
+
+Можно указать БИК для которого генерируется счет:
+
+```ruby
+  Faker::Russian.correspondent_account(bik: '0440754281') # => '30100000341569331281'
 ```
 
 ### ОКАТО

--- a/lib/faker/russian.rb
+++ b/lib/faker/russian.rb
@@ -11,5 +11,6 @@ module Faker
     extend Kpp
     extend Okato
     extend Okpo
+    extend CorrespondentAccount
   end
 end

--- a/lib/faker/russian/correspondent_account.rb
+++ b/lib/faker/russian/correspondent_account.rb
@@ -1,0 +1,24 @@
+module Faker
+  module Russian
+    module CorrespondentAccount
+      def correspondent_account(options = {})
+        options.assert_valid_keys(:sequence_number, :bik)
+
+        sequence = find_sequence(options[:sequence_number])
+        member_number = find_member_number(options[:bik], sequence)
+
+        '301' + sprintf("%014d", sequence.rand(1_000_000_000)) + member_number
+      end
+
+    private
+
+      def find_member_number(bik, sequence)
+        if bik && bik.length > 3
+          bik[-3..-1]
+        else
+          "%03d" % sequence.rand(1_000)
+        end
+      end
+    end
+  end
+end

--- a/spec/faker/russian/correspondent_account_spec.rb
+++ b/spec/faker/russian/correspondent_account_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Faker::Russian do
+  describe '#correspondent_account' do
+    let(:bik) { Faker::Russian.bik }
+
+    before(:all) do
+      DummyModel.reset_callbacks(:validate)
+      DummyModel.validates(:field, ks_format: true)
+    end
+
+    it 'generate valid correspondent account without arguments' do
+      100.times do
+        expect(DummyModel.new(field: Faker::Russian.correspondent_account)).to be_valid
+      end
+    end
+
+    it 'generate valid correspondent account with bik' do
+      100.times do
+        expect(DummyModel.new(field: Faker::Russian.correspondent_account(bik: bik))).to be_valid
+      end
+    end
+
+    it 'generate correspondent account for given bik' do
+      100.times do
+        expect(Faker::Russian.correspondent_account(bik: bik)[-3..-1]).to eq bik[-3..-1]
+      end
+    end
+
+    it 'generate difference correspondent account with sequence' do
+      sequenced_cas = 1000.times.map{ |n| Faker::Russian.correspondent_account(sequence_number: n) }
+      expect(sequenced_cas.size).to eq(sequenced_cas.uniq.size)
+    end
+
+    it 'generate same correspondent accounts for sequence' do
+      array1 = 1000.times.map{ |n| Faker::Russian.correspondent_account(sequence_number: n) }
+      array2 = 1000.times.map{ |n| Faker::Russian.correspondent_account(sequence_number: n) }
+      expect(array1).to eq(array2)
+    end
+
+    it 'permit just a few options' do
+      expect{ Faker::Russian.correspondent_account(shit: 'shit') }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Я изменил название метода с `ks` на `correspondent_account` для соответствия английскому переводу. Но для старого названия создал алиас.
