### PR TITLE
Including required methods from activesupport

### DIFF
--- a/faker-russian.gemspec
+++ b/faker-russian.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activesupport'
+
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 10'
   spec.add_development_dependency 'rspec', '~> 3'

--- a/lib/faker/russian.rb
+++ b/lib/faker/russian.rb
@@ -1,3 +1,6 @@
+require 'active_support/core_ext/hash/keys.rb'
+require 'active_support/core_ext/object/blank.rb'
+
 Dir[File.dirname(__FILE__) + '/russian/**/*.rb'].each{ |f| require f }
 
 module Faker


### PR DESCRIPTION
Hi. 
We are using this gem for non rails project. And i dont think it's really required to add whole rails as dewpendency. So, i am proposing add exactly methods from activesupport.